### PR TITLE
Enable task caching (Fixes #83)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -9,7 +9,7 @@ plugins {
 }
 
 group = "com.github.jk1"
-version = "1.1"
+version = "1.2"
 
 sourceCompatibility = 1.6
 targetCompatibility = 1.6

--- a/src/main/groovy/com/github/jk1/license/LicenseReportExtension.groovy
+++ b/src/main/groovy/com/github/jk1/license/LicenseReportExtension.groovy
@@ -69,16 +69,4 @@ class LicenseReportExtension {
                 excludes.contains("$module.moduleGroup:$module.moduleName")
     }
 
-    // configuration snapshot for the up-to-date check
-    String getSnapshot() {
-        StringBuilder builder = new StringBuilder()
-        projects.each { builder.append(it.name) }
-        renderers.each { builder.append(it.class.name) }
-        importers.each { builder.append(it.class.name) }
-        filters.each { builder.append(it.class.name) }
-        configurations.each { builder.append(it) }
-        excludeGroups.each { builder.append(it) }
-        excludes.each { builder.append(it) }
-        return builder.toString()
-    }
 }

--- a/src/main/groovy/com/github/jk1/license/reader/ProjectReader.groovy
+++ b/src/main/groovy/com/github/jk1/license/reader/ProjectReader.groovy
@@ -72,7 +72,7 @@ class ProjectReader {
         }
     }
 
-    private static Set<Configuration> findConfigured(Project project) {
+    static Set<Configuration> findConfigured(Project project) {
         project.configurations.findAll { config -> config.name in project.licenseReport.configurations }
     }
 

--- a/src/test/groovy/com/github/jk1/license/ReportTaskTestSpec.groovy
+++ b/src/test/groovy/com/github/jk1/license/ReportTaskTestSpec.groovy
@@ -1,0 +1,113 @@
+/*
+ * Copyright 2018 Evgeny Naumenko <jk.vc@mail.ru>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.github.jk1.license
+
+import org.gradle.testkit.runner.BuildResult
+import org.gradle.testkit.runner.GradleRunner
+import org.gradle.testkit.runner.TaskOutcome
+import org.junit.Rule
+import org.junit.rules.TemporaryFolder
+import spock.lang.Specification
+
+class ReportTaskTestSpec extends Specification {
+    @Rule
+    final TemporaryFolder testProjectDir = new TemporaryFolder()
+
+    File buildFile
+    File localBuildCacheDirectory
+
+    def setup() {
+        buildFile = testProjectDir.newFile('build.gradle')
+        localBuildCacheDirectory = testProjectDir.newFolder('.local-cache')
+        testProjectDir.newFile('settings.gradle') << """
+        buildCache {
+            local {
+                directory '${localBuildCacheDirectory.toURI()}'
+            }
+        }
+    """
+
+    }
+
+    def "should cache task outputs"() {
+        given:
+        buildFile << """
+            plugins {
+                id 'com.github.jk1.dependency-license-report'
+            }
+            
+            repositories {
+                mavenCentral()
+            }
+            
+            apply plugin: 'java'
+            
+            dependencies {
+                compile "junit:junit:\${project.ext.junitVersion}"
+            }
+        """
+
+        when:
+        BuildResult result = GradleRunner.create()
+            .withDebug(true)
+        .forwardOutput()
+            .withPluginClasspath()
+            .withProjectDir(testProjectDir.getRoot())
+            .withArguments( '-i', '--build-cache', "generateLicenseReport", "-PjunitVersion=4.12")
+            .build()
+
+        then:
+        result.task(':generateLicenseReport').outcome == TaskOutcome.SUCCESS
+
+        when:
+        result = GradleRunner.create()
+            .withDebug(true)
+        .forwardOutput()
+            .withPluginClasspath()
+            .withProjectDir(testProjectDir.getRoot())
+            .withArguments( '-i', '--build-cache', "generateLicenseReport", "-PjunitVersion=4.12")
+            .build()
+
+        then:
+        result.task(':generateLicenseReport').outcome == TaskOutcome.UP_TO_DATE
+
+        when:
+        result = GradleRunner.create()
+            .withDebug(true)
+        .forwardOutput()
+            .withPluginClasspath()
+            .withProjectDir(testProjectDir.getRoot())
+            .withArguments( '-i', '--build-cache', "clean", "generateLicenseReport", "-PjunitVersion=4.12")
+            .build()
+
+        then:
+        result.task(':generateLicenseReport').outcome == TaskOutcome.FROM_CACHE
+
+        when:
+        result = GradleRunner.create()
+            .withDebug(true)
+        .forwardOutput()
+            .withPluginClasspath()
+            .withProjectDir(testProjectDir.getRoot())
+            .withArguments( '-i', '--build-cache', "generateLicenseReport", "-PjunitVersion=4.11")
+            .build()
+
+        then:
+        result.task(':generateLicenseReport').outcome == TaskOutcome.SUCCESS
+
+    }
+}


### PR DESCRIPTION
- all inputs to `licenseReport` are task inputs
- all project configurations are resolved via an `@InputFiles` annotated
  method to ensure that changing the project dependencies causes the
  task to not use cached values